### PR TITLE
Add Apache Mahout to Java Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open-source applications and proof-of-concepts demonstrating data science modeli
 |[Charts](https://github.com/HanSolo/charts)|Charting|Scientific JavaFX charting library in development|
 |[CoreNLP](https://stanfordnlp.github.io/CoreNLP/)|Natural Language Processing|Natural language processing toolkit|
 |[Renjin](https://en.wikipedia.org/wiki/Renjin)|Interop|R JVM implementation|
-
+|[Apache Mahout](https://mahout.apache.org/)|Linear Algebra|Distributed framework for regression, clustering and recommendation|
 
 # Resources for Python Developers
 


### PR DESCRIPTION
Mahout is written in Java and Scala and provides some algorithms to implement features like movie recommendation and spam filtering. Unfortunately I couldn't find any extensions for Kotlin.

Here is a sample code adapted from website.

```kotlin
val dataModel = FileDataModel(File("users-and-movies-rating.csv"))
val userSimilarity = PearsonCorrelationSimilarity(dataModel)
val userNeighborhood = ThresholdUserNeighborhood(/*threshold*/ 0.2, userSimilarity, dataModel)

val predictor = GenericUserBasedRecommender(dataModel, userNeighborhood, userSimilarity)
val recommendations = predictor.recommend(/*userID*/ 2, /*howMany*/ 1).map { it.itemID to it.value }

assertThat(recommendations)
        .contains(12L to 4.8328104F) // User with id 2 would give 4.8 stars to movie 12
```